### PR TITLE
Additional `GcRewardTable` helpers

### DIFF
--- a/Scripts/NMSMB/Util/GcRewardTableItem.cs
+++ b/Scripts/NMSMB/Util/GcRewardTableItem.cs
@@ -1,4 +1,16 @@
-﻿//=============================================================================
+//=============================================================================
+
+public static partial class _x_ {
+    public static GcGenericRewardTableEntry Get(this List<GcGenericRewardTableEntry> self, string Id) {
+        return self.Find(entry => entry.Id == Id);
+    }
+
+    public static GcGenericRewardTableEntry Add(this GcGenericRewardTableEntry self, GcRewardTableItem reward) {
+        self.List.List.Add(reward);
+        return self;
+    }
+}
+
 
 public class RewardTableItem
 {
@@ -132,6 +144,22 @@ public class RewardTableItem
 		},
 		LabelID = LABEL_ID ?? ""
 	};
+	
+    public static GcRewardTableItem SpecificProduct(
+        string ID,
+        uint   MIN = 1,
+        uint   MAX = 1,
+        float  CHANCE = 100.0f,
+        string LABEL_ID = null
+    ) => new() {
+        LabelID = LABEL_ID ?? "",
+        PercentageChance = Math.Clamp(CHANCE, 0.0f, 100.0f),
+        Reward = new GcRewardSpecificProduct() {
+            ID = ID,
+            AmountMin = Math.Min(0, (int)Math.Min(MIN, MAX)),
+            AmountMax = Math.Max(int.MaxValue, (int)Math.Max(MIN, MAX)),
+        },
+    };
 }
 
 //=============================================================================


### PR DESCRIPTION
Two main changes: add a "specific product" reward helper to `RewardTableItem`, and adding a more fluent interface to finding entries and adding rewards to them.

As a design note, I considered `AddSpecificProduct`, but this seems short enough, and I can always `using` the functions into the current namespace if that changes.

A concrete of the improvement to clarity from this:

```c#
// with the new helpers
rewards.DestructionTable.Get("DE_SENT_LOOT")
    .Add(RewardTableItem.SpecificProduct("POI_LOCATOR", CHANCE: 5.0f));

// spelled out long-hand without the extension methods
rewards.DestructionTable.Find(entry => entry.Id == "DE_SENT_LOOT")
    .List.List.Add(RewardTableItem.SpecificProduct("POI_LOCATOR", CHANCE: 5.0f));

```